### PR TITLE
Add api error handler to useSpeechRecognition

### DIFF
--- a/examples/src/useSpeechRecognition.jsx
+++ b/examples/src/useSpeechRecognition.jsx
@@ -90,7 +90,7 @@ const Example = () => {
               rows={3}
               disabled
             />
-            <button type="button" onClick={toggle}>
+            <button disabled={blocked} type="button" onClick={toggle}>
               {listening ? 'Stop' : 'Listen'}
             </button>
             {blocked && <p style={{ color: 'red' }}>The microphone is blocked for this site in your browser.</p>}

--- a/examples/src/useSpeechRecognition.jsx
+++ b/examples/src/useSpeechRecognition.jsx
@@ -18,6 +18,7 @@ const languageOptions = [
 const Example = () => {
   const [lang, setLang] = useState('en-AU');
   const [value, setValue] = useState('');
+  const [blocked, setBlocked] = useState(false);
 
   const onEnd = () => {
     // You could do something here after listening has finished
@@ -32,10 +33,10 @@ const Example = () => {
   };
 
   const onError = (event) => {
-    if(event.error === "not-allowed") {
-      console.log("Browser blocked microphone for this site");
+    if (event.error === 'not-allowed') {
+      setBlocked(true);
     }
-  }
+  };
 
   const {
     listen,
@@ -46,7 +47,10 @@ const Example = () => {
 
   const toggle = listening
     ? stop
-    : () => listen({ lang });
+    : () => {
+      setBlocked(false);
+      listen({ lang });
+    };
 
   return (
     <Container>
@@ -89,6 +93,7 @@ const Example = () => {
             <button type="button" onClick={toggle}>
               {listening ? 'Stop' : 'Listen'}
             </button>
+            {blocked && <p style={{ color: 'red' }}>The microphone is blocked for this site in your browser.</p>}
           </React.Fragment>
         )}
       </form>

--- a/examples/src/useSpeechRecognition.jsx
+++ b/examples/src/useSpeechRecognition.jsx
@@ -31,12 +31,18 @@ const Example = () => {
     setLang(event.target.value);
   };
 
+  const onError = (event) => {
+    if(event.error === "not-allowed") {
+      console.log("Browser blocked microphone for this site");
+    }
+  }
+
   const {
     listen,
     listening,
     stop,
     supported
-  } = useSpeechRecognition({ onResult, onEnd });
+  } = useSpeechRecognition({ onResult, onEnd, onError });
 
   const toggle = listening
     ? stop

--- a/src/SpeechRecognition.jsx
+++ b/src/SpeechRecognition.jsx
@@ -9,12 +9,14 @@ import PropTypes from 'prop-types';
 const propTypes = {
   children: PropTypes.func.isRequired,
   onEnd: PropTypes.func,
-  onResult: PropTypes.func
+  onResult: PropTypes.func,
+  onError: PropTypes.func
 };
 
 const defaultProps = {
   onEnd: () => {},
-  onResult: () => {}
+  onResult: () => {},
+  onError: () => {}
 };
 
 window.SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -26,7 +28,8 @@ const SpeechRekognition = (props) => {
   const {
     children,
     onEnd,
-    onResult
+    onResult,
+    onError
   } = props;
 
   const processResult = (event) => {
@@ -36,6 +39,14 @@ const SpeechRekognition = (props) => {
       .join('');
 
     onResult(transcript);
+  };
+
+  const handleError = (event) => {
+    if (event.error === 'not-allowed') {
+      recognition.current.onend = () => {};
+      setListening(false);
+    }
+    onError(event);
   };
 
   const listen = (args = {}) => {
@@ -48,6 +59,7 @@ const SpeechRekognition = (props) => {
     recognition.current.lang = lang;
     recognition.current.interimResults = interimResults;
     recognition.current.onresult = processResult;
+    recognition.current.onerror = handleError;
     // SpeechRecognition stops automatically after inactivity
     // We want it to keep going until we tell it to stop
     recognition.current.onend = () => recognition.current.start();

--- a/src/useSpeechRecognition.js
+++ b/src/useSpeechRecognition.js
@@ -9,7 +9,8 @@ window.SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecogn
 const useSpeechRecognition = (props = {}) => {
   const {
     onEnd = () => {},
-    onResult = () => {}
+    onResult = () => {},
+    onError = () => {}
   } = props;
   const recognition = useRef(null);
   const [listening, setListening] = useState(false);
@@ -24,6 +25,14 @@ const useSpeechRecognition = (props = {}) => {
     onResult(transcript);
   };
 
+  const handleError = (event) => {
+    if (event.error === "not-allowed") {
+        //this prevents an infinite loop of error handling:
+        recognition.current = new window.SpeechRecognition();  
+    }
+    onError(event);
+  }
+
   const listen = (args = {}) => {
     if (listening) return;
     const {
@@ -33,6 +42,7 @@ const useSpeechRecognition = (props = {}) => {
     recognition.current.lang = lang;
     recognition.current.interimResults = interimResults;
     recognition.current.onresult = processResult;
+    recognition.current.onerror = handleError;
     recognition.current.continuous = continuous;
     recognition.current.maxAlternatives = maxAlternatives;
     if (grammars) {
@@ -48,6 +58,7 @@ const useSpeechRecognition = (props = {}) => {
     if (!listening) return;
     recognition.current.onresult = () => {};
     recognition.current.onend = () => {};
+    recognition.current.onerror = () => {};
     setListening(false);
     recognition.current.stop();
     onEnd();

--- a/src/useSpeechRecognition.js
+++ b/src/useSpeechRecognition.js
@@ -26,12 +26,12 @@ const useSpeechRecognition = (props = {}) => {
   };
 
   const handleError = (event) => {
-    if (event.error === "not-allowed") {
-        //this prevents an infinite loop of error handling:
-        recognition.current = new window.SpeechRecognition();  
+    if (event.error === 'not-allowed') {
+      recognition.current.onend = () => {};
+      setListening(false);
     }
     onError(event);
-  }
+  };
 
   const listen = (args = {}) => {
     if (listening) return;

--- a/test/SpeechRecognition.spec.jsx
+++ b/test/SpeechRecognition.spec.jsx
@@ -7,7 +7,11 @@ const mockOnResult = jest.fn();
 const mockOnError = jest.fn();
 const TestComponent = () => null;
 const Example = () => (
-  <SpeechRecognition onEnd={mockOnEnd} onResult={mockOnResult}>
+  <SpeechRecognition
+    onEnd={mockOnEnd}
+    onResult={mockOnResult}
+    onError={mockOnError}
+  >
     {props => <TestComponent {...props} />}
   </SpeechRecognition>
 );

--- a/test/SpeechRecognition.spec.jsx
+++ b/test/SpeechRecognition.spec.jsx
@@ -4,6 +4,7 @@ import runTests from './shared/speechRecognitionTests';
 
 const mockOnEnd = jest.fn();
 const mockOnResult = jest.fn();
+const mockOnError = jest.fn();
 const TestComponent = () => null;
 const Example = () => (
   <SpeechRecognition onEnd={mockOnEnd} onResult={mockOnResult}>
@@ -15,5 +16,6 @@ runTests({
   Example,
   TestComponent,
   mockOnResult,
-  mockOnEnd
+  mockOnEnd,
+  mockOnError
 });

--- a/test/mocks/MockRecognition.jsx
+++ b/test/mocks/MockRecognition.jsx
@@ -2,18 +2,24 @@ class MockRecognition {
   constructor() {
     this.onresult = () => {};
     this.onend = () => {};
+    this.onerror = () => {};
     this.start = () => {
-      // By calling startMock with the current settings,
-      // we can test that they were updated correctly
-      MockRecognition.start({
-        lang: this.lang,
-        interimResults: this.interimResults
-      });
+      try {
+        // By calling startMock with the current settings,
+        // we can test that they were updated correctly
+        MockRecognition.start({
+          lang: this.lang,
+          interimResults: this.interimResults
+        });
 
-      setTimeout(() => {
-        this.onresult(MockRecognition.mockResult);
-        this.onend();
-      }, 500);
+        setTimeout(() => {
+          this.onresult(MockRecognition.mockResult);
+          this.onend();
+        }, 500);
+      }
+      catch (err) {
+        this.onerror(err);
+      }
     };
 
     this.stop = () => {

--- a/test/mocks/MockRecognition.jsx
+++ b/test/mocks/MockRecognition.jsx
@@ -16,8 +16,7 @@ class MockRecognition {
           this.onresult(MockRecognition.mockResult);
           this.onend();
         }, 500);
-      }
-      catch (err) {
+      } catch (err) {
         this.onerror(err);
       }
     };

--- a/test/shared/speechRecognitionTests.jsx
+++ b/test/shared/speechRecognitionTests.jsx
@@ -43,16 +43,6 @@ const SpeechRecognitionTests = ({
       });
     });
 
-    describe('when the user blocks permission', () => {
-      beforeAll(() => {
-        MockRecognition.start = jest.fn(() => { throw new Error('not allowed'); });
-      });
-      
-      it.only('calls the onError function', () => {
-        expect(mockOnError.mock.calls.length).toBe(1);
-      });
-    });
-
     describe('listen()', () => {
       let args;
 
@@ -99,6 +89,16 @@ const SpeechRecognitionTests = ({
           const receivedArgs = MockRecognition.start.mock.calls[0][0];
           expect(receivedArgs.lang).toEqual('en-US');
           expect(receivedArgs.interimResults).toBe(false);
+        });
+      });
+
+      describe('when the user blocks permission', () => {
+        beforeAll(() => {
+          MockRecognition.start = jest.fn(() => { throw new Error('not allowed'); });
+        });
+        
+        it.only('calls the onError function', () => {
+          expect(mockOnError.mock.calls.length).toBe(1);
         });
       });
 

--- a/test/shared/speechRecognitionTests.jsx
+++ b/test/shared/speechRecognitionTests.jsx
@@ -97,7 +97,7 @@ const SpeechRecognitionTests = ({
           MockRecognition.start = jest.fn(() => { throw new Error('not allowed'); });
         });
         
-        it.only('calls the onError function', () => {
+        it('calls the onError function', () => {
           expect(mockOnError.mock.calls.length).toBe(1);
         });
       });

--- a/test/shared/speechRecognitionTests.jsx
+++ b/test/shared/speechRecognitionTests.jsx
@@ -43,6 +43,16 @@ const SpeechRecognitionTests = ({
       });
     });
 
+    describe('when the user blocks permission', () => {
+      beforeAll(() => {
+        MockRecognition.start = jest.fn(() => { throw new Error('not allowed'); });
+      });
+      
+      it.only('calls the onError function', () => {
+        expect(mockOnError.mock.calls.length).toBe(1);
+      });
+    });
+
     describe('listen()', () => {
       let args;
 

--- a/test/shared/speechRecognitionTests.jsx
+++ b/test/shared/speechRecognitionTests.jsx
@@ -7,7 +7,8 @@ const SpeechRecognitionTests = ({
   Example,
   TestComponent,
   mockOnResult,
-  mockOnEnd
+  mockOnEnd,
+  mockOnError
 }) => {
   jest.useFakeTimers();
 

--- a/test/shared/speechRecognitionTests.jsx
+++ b/test/shared/speechRecognitionTests.jsx
@@ -96,7 +96,7 @@ const SpeechRecognitionTests = ({
         beforeAll(() => {
           MockRecognition.start = jest.fn(() => { throw new Error('not allowed'); });
         });
-        
+
         it('calls the onError function', () => {
           expect(mockOnError.mock.calls.length).toBe(1);
         });

--- a/test/useSpeechRecognition.spec.jsx
+++ b/test/useSpeechRecognition.spec.jsx
@@ -4,11 +4,13 @@ import runTests from './shared/speechRecognitionTests';
 
 const mockOnEnd = jest.fn();
 const mockOnResult = jest.fn();
+const mockOnError = jest.fn();
 const TestComponent = () => null;
 const Example = () => {
   const props = useSpeechRecognition({
     onResult: mockOnResult,
-    onEnd: mockOnEnd
+    onEnd: mockOnEnd,
+    onError: mockOnError
   });
 
   return (
@@ -20,5 +22,6 @@ runTests({
   Example,
   TestComponent,
   mockOnResult,
-  mockOnEnd
+  mockOnEnd,
+  mockOnError
 });


### PR DESCRIPTION
Allow devs to code for errors thrown by the SpeechRecognition API. Detect if the error is due to "not allowed" (i.e. user denied microphone access) and if so, stop trying to listen.